### PR TITLE
Feature/enable making authorization mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,10 @@ function isTokenPayload (token: any): token is ITokenPayload {
 // This is your AWS handler
 const helloWorld = async (event: IAuthorizedEvent<ITokenPayload>) => {
   // The middleware adds auth information if a valid token was added
-  // If no auth was found, event.auth will remain undefined. You have to check
-  // that it exists.
-  if (event.auth == null) {
-    throw createHttpError(401, 'No valid bearer token was set in the authorization header', {
-      type: 'AuthenticationRequired'
-    })
-  }
-
-  // Check for authorization
-  if (event.auth.permissions.indexOf('helloWorld') === -1) {
-    throw createHttpError(403, `User not authorized for helloWorld, only found permissions [${event.auth.permissions.join(', ')}]`, {
+  // If no auth was found and credentialsRequired is set to true, a 401 will be thrown. If auth exists you
+  // have to check that it has the expected form.
+  if (event.auth!.permissions.indexOf('helloWorld') === -1) {
+    throw createHttpError(403, `User not authorized for helloWorld, only found permissions [${event.auth!.permissions.join(', ')}]`, {
       type: 'NotAuthorized'
     })
   }
@@ -65,6 +58,8 @@ export const handler = middy(helloWorld)
   .use(JWTAuthMiddleware({
     /** Algorithm to verify JSON web token signature */
     algorithm: EncryptionAlgorithms.HS256,
+    /** An optional boolean that enables making authorization mandatory */
+    credentialsRequired: true,
     /** An optional function that checks whether the token payload is formatted correctly */
     isPayload: isTokenPayload,
     /** A string or buffer containing either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA */

--- a/examples/helloWorld.int-spec.ts
+++ b/examples/helloWorld.int-spec.ts
@@ -49,7 +49,7 @@ describe('Handler with JWT Auth middleware', () => {
       })
   })
 
-  it('returns 401 and error message if not authenticated', async () => {
+  it('returns 400 and error message if not authenticated', async () => {
     const token = JWT.sign({ iat: 1, permission: 'helloWorld' }, 'secret')
     return server
       .get('/hello')
@@ -70,7 +70,7 @@ describe('Handler with JWT Auth middleware', () => {
       })
   )
 
-  it('returns 400 and error message if payload is malformed', async () => {
+  it('returns 401 and error message if payload is malformed', async () => {
     return server
       .get('/hello')
       .set('Authorization', `Malformed token`)

--- a/examples/helloWorld.int-spec.ts
+++ b/examples/helloWorld.int-spec.ts
@@ -79,4 +79,13 @@ describe('Handler with JWT Auth middleware', () => {
         expect(res.text).toEqual('Format should be "Authorization: Bearer [token]", received "Authorization: Malformed token" instead')
       })
   })
+
+  it('returns 401 and error message if token is missing', async () => {
+    return server
+      .get('/hello')
+      .expect(401)
+      .then((res: any) => {
+        expect(res.text).toEqual('No valid bearer token was set in the authorization header')
+      })
+  })
 })

--- a/src/JWTAuthMiddleware.spec.ts
+++ b/src/JWTAuthMiddleware.spec.ts
@@ -348,6 +348,38 @@ describe('JWTAuthMiddleware', () => {
           })
         )
       })
+      it('rejects if authorization is required and no authorization header is set', async () => {
+        const next = jest.fn()
+        const options = {
+          algorithm: EncryptionAlgorithms.HS256,
+          authorizationRequired: true,
+          secretOrPublicKey: 'secret'
+        }
+        await expect(
+          JWTAuthMiddleware(options).before(
+            {
+              callback: jest.fn(),
+              context: {} as any,
+              error: {} as Error,
+              // is there a way to make the headers optional based on the options passed to JWTAuthMiddleware?
+              // @ts-ignore
+              event: {
+                httpMethod: 'GET'
+              },
+              response: null
+            },
+            next
+          )
+        ).rejects.toEqual(
+          createHttpError(
+            401,
+            'No valid bearer token was set in the authorization header',
+            {
+              type: 'AuthenticationRequired'
+            }
+          )
+        )
+      })
     })
 
     describe('with a payload type guard', () => {

--- a/src/JWTAuthMiddleware.spec.ts
+++ b/src/JWTAuthMiddleware.spec.ts
@@ -361,8 +361,6 @@ describe('JWTAuthMiddleware', () => {
               callback: jest.fn(),
               context: {} as any,
               error: {} as Error,
-              // is there a way to make the headers optional based on the options passed to JWTAuthMiddleware?
-              // @ts-ignore
               event: {
                 httpMethod: 'GET'
               },

--- a/src/JWTAuthMiddleware.spec.ts
+++ b/src/JWTAuthMiddleware.spec.ts
@@ -352,7 +352,7 @@ describe('JWTAuthMiddleware', () => {
         const next = jest.fn()
         const options = {
           algorithm: EncryptionAlgorithms.HS256,
-          authorizationRequired: true,
+          credentialsRequired: true,
           secretOrPublicKey: 'secret'
         }
         await expect(

--- a/src/JWTAuthMiddleware.ts
+++ b/src/JWTAuthMiddleware.ts
@@ -147,6 +147,7 @@ export class JWTAuthMiddleware<Payload> {
   ): string | undefined {
     this.logger('Checking whether event contains authorization header')
     if (!isAuthorizedEvent(event)) {
+      this.logger('No authorization header found')
       if (this.options.credentialsRequired) {
         throw createHttpError(
           401,
@@ -156,7 +157,6 @@ export class JWTAuthMiddleware<Payload> {
           }
         )
       }
-      this.logger('No authorization header found')
       return
     }
     this.logger(

--- a/src/JWTAuthMiddleware.ts
+++ b/src/JWTAuthMiddleware.ts
@@ -68,7 +68,7 @@ export class JWTAuthMiddleware<Payload> {
    * fallback.
    * @param event - The event to check
    */
-  public before: MiddlewareFunction<IAuthorizedEvent, any> = async ({
+  public before: MiddlewareFunction<any, any> = async ({
     event
   }: HandlerLambda<IAuthorizedEvent<Payload>>) => {
     this.logger('Checking whether event.auth already is populated')

--- a/src/JWTAuthMiddleware.ts
+++ b/src/JWTAuthMiddleware.ts
@@ -147,6 +147,15 @@ export class JWTAuthMiddleware<Payload> {
   ): string | undefined {
     this.logger('Checking whether event contains authorization header')
     if (!isAuthorizedEvent(event)) {
+      if (this.options.authorizationRequired) {
+        throw createHttpError(
+          401,
+          'No valid bearer token was set in the authorization header',
+          {
+            type: 'AuthenticationRequired'
+          }
+        )
+      }
       this.logger('No authorization header found')
       return
     }

--- a/src/JWTAuthMiddleware.ts
+++ b/src/JWTAuthMiddleware.ts
@@ -147,7 +147,7 @@ export class JWTAuthMiddleware<Payload> {
   ): string | undefined {
     this.logger('Checking whether event contains authorization header')
     if (!isAuthorizedEvent(event)) {
-      if (this.options.authorizationRequired) {
+      if (this.options.credentialsRequired) {
         throw createHttpError(
           401,
           'No valid bearer token was set in the authorization header',

--- a/src/interfaces/IAuthOptions.spec.ts
+++ b/src/interfaces/IAuthOptions.spec.ts
@@ -98,11 +98,11 @@ describe('IAuthOptions', () => {
       ).toBe(true)
     })
 
-    it('accepts data that has algorithm, a string secretOrPublicKey and a boolean authorizationRequired', () => {
+    it('accepts data that has algorithm, a string secretOrPublicKey and a boolean credentialsRequired', () => {
       expect(
         isAuthOptions({
           algorithm: EncryptionAlgorithms.ES256,
-          authorizationRequired: true,
+          credentialsRequired: true,
           secretOrPublicKey: 'secret'
         })
       ).toBe(true)
@@ -166,11 +166,11 @@ describe('IAuthOptions', () => {
       ).toBe(false)
     })
 
-    it('rejects data with an authorizationRequired that is not a boolean', () => {
+    it('rejects data with an credentialsRequired that is not a boolean', () => {
       expect(
         isAuthOptions({
           algorithm: EncryptionAlgorithms.ES256,
-          authorizationRequired: '',
+          credentialsRequired: '',
           secretOrPublicKey: 'secret'
         })
       ).toBe(false)

--- a/src/interfaces/IAuthOptions.spec.ts
+++ b/src/interfaces/IAuthOptions.spec.ts
@@ -98,6 +98,16 @@ describe('IAuthOptions', () => {
       ).toBe(true)
     })
 
+    it('accepts data that has algorithm, a string secretOrPublicKey and a boolean authorizationRequired', () => {
+      expect(
+        isAuthOptions({
+          algorithm: EncryptionAlgorithms.ES256,
+          authorizationRequired: true,
+          secretOrPublicKey: 'secret'
+        })
+      ).toBe(true)
+    })
+
     it('rejects data that is null', () => {
       expect(isAuthOptions(null)).toBe(false)
     })
@@ -152,6 +162,16 @@ describe('IAuthOptions', () => {
           algorithm: EncryptionAlgorithms.ES256,
           secretOrPublicKey: 'secret',
           tokenSource: {}
+        })
+      ).toBe(false)
+    })
+
+    it('rejects data with an authorizationRequired that is not a boolean', () => {
+      expect(
+        isAuthOptions({
+          algorithm: EncryptionAlgorithms.ES256,
+          authorizationRequired: '',
+          secretOrPublicKey: 'secret'
         })
       ).toBe(false)
     })

--- a/src/interfaces/IAuthOptions.ts
+++ b/src/interfaces/IAuthOptions.ts
@@ -31,7 +31,7 @@ export interface IAuthOptions<P = any> {
   /** An optional function to get the authorization token from the event */
   tokenSource?: (event: any) => string
   /** An optional boolean that allows making authorization necessary */
-  authorizationRequired?: boolean
+  credentialsRequired?: boolean
 }
 
 export function isAuthOptions (options: any): options is IAuthOptions {
@@ -46,7 +46,7 @@ export function isAuthOptions (options: any): options is IAuthOptions {
       Buffer.isBuffer(options.secretOrPublicKey)) &&
     (options.tokenSource === undefined ||
       typeof options.tokenSource === 'function') &&
-    (options.authorizationRequired === undefined ||
-      typeof options.authorizationRequired === 'boolean')
+    (options.credentialsRequired === undefined ||
+      typeof options.credentialsRequired === 'boolean')
   )
 }

--- a/src/interfaces/IAuthOptions.ts
+++ b/src/interfaces/IAuthOptions.ts
@@ -30,6 +30,8 @@ export interface IAuthOptions<P = any> {
   secretOrPublicKey: string | Buffer
   /** An optional function to get the authorization token from the event */
   tokenSource?: (event: any) => string
+  /** An optional boolean that allows making authorization necessary */
+  authorizationRequired?: boolean
 }
 
 export function isAuthOptions (options: any): options is IAuthOptions {
@@ -43,6 +45,8 @@ export function isAuthOptions (options: any): options is IAuthOptions {
     (typeof options.secretOrPublicKey === 'string' ||
       Buffer.isBuffer(options.secretOrPublicKey)) &&
     (options.tokenSource === undefined ||
-      typeof options.tokenSource === 'function')
+      typeof options.tokenSource === 'function') &&
+    (options.authorizationRequired === undefined ||
+      typeof options.authorizationRequired === 'boolean')
   )
 }


### PR DESCRIPTION
The goal of this is to enable making authorization mandatory by just passing an option to the middleware instead of having to manually check after the middleware has finished.