### PR TITLE
feat: support API Gateway HTTP APIs

### DIFF
--- a/examples/helloWorld.int-spec.ts
+++ b/examples/helloWorld.int-spec.ts
@@ -11,81 +11,83 @@ import superagent from 'superagent'
 superagent.parse['application/json'] = superagent.parse.text
 
 describe('Handler with JWT Auth middleware', () => {
-  it('returns 200 and "Hello world! Here\'s your token: {TOKEN}" with the token used if authorized', async () => {
-    const token = JWT.sign({ permissions: ['helloWorld'] }, 'secret')
-    return server
-      .get('/hello')
-      .set('Authorization', `Bearer ${token}`)
-      .expect(200)
-      .then((res: any) => {
-        // TODO: Use this code instead as soon as the error middleware sets the correct content-type
-        // expect(res.body.data).toEqual('Hello world!')
-        const body = JSON.parse(res.text)
-        expect(body.data).toEqual(`Hello world! Here's your token: ${token}`)
-      })
-  })
+  describe.each(['rest', 'http'])('with %s API', apiType => {
+    it('returns 200 and "Hello world! Here\'s your token: {TOKEN}" with the token used if authorized', async () => {
+      const token = JWT.sign({ permissions: ['helloWorld'] }, 'secret')
+      return server
+        .get(`/${apiType}/hello`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+        .then((res: any) => {
+          // TODO: Use this code instead as soon as the error middleware sets the correct content-type
+          // expect(res.body.data).toEqual('Hello world!')
+          const body = JSON.parse(res.text)
+          expect(body.data).toEqual(`Hello world! Here's your token: ${token}`)
+        })
+    })
 
-  it('returns 200 and "Hello world!" if authorized via query parameter', async () => {
-    const token = JWT.sign({ permissions: ['helloWorld'] }, 'secret')
-    return server
-      .get(`/hello?token=${token}`)
-      .expect(200)
-      .then((res: any) => {
-        // TODO: Use this code instead as soon as the error middleware sets the correct content-type
-        // expect(res.body.data).toEqual('Hello world!')
-        const body = JSON.parse(res.text)
-        expect(body.data).toEqual(`Hello world! Here's your token: ${token}`)
-      })
-  })
+    it('returns 200 and "Hello world!" if authorized via query parameter', async () => {
+      const token = JWT.sign({ permissions: ['helloWorld'] }, 'secret')
+      return server
+        .get(`/${apiType}/hello?token=${token}`)
+        .expect(200)
+        .then((res: any) => {
+          // TODO: Use this code instead as soon as the error middleware sets the correct content-type
+          // expect(res.body.data).toEqual('Hello world!')
+          const body = JSON.parse(res.text)
+          expect(body.data).toEqual(`Hello world! Here's your token: ${token}`)
+        })
+    })
 
-  it('returns 403 and error message if not authorized', async () => {
-    const token = JWT.sign({ permissions: [] }, 'secret')
-    return server
-      .get('/hello')
-      .set('Authorization', `Bearer ${token}`)
-      .expect(403)
-      .then((res: any) => {
-        expect(res.text).toEqual('User not authorized for helloWorld, only found permissions []')
-      })
-  })
+    it('returns 403 and error message if not authorized', async () => {
+      const token = JWT.sign({ permissions: [] }, 'secret')
+      return server
+        .get(`/${apiType}/hello`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(403)
+        .then((res: any) => {
+          expect(res.text).toEqual('User not authorized for helloWorld, only found permissions []')
+        })
+    })
 
-  it('returns 400 and error message if not authenticated', async () => {
-    const token = JWT.sign({ iat: 1, permission: 'helloWorld' }, 'secret')
-    return server
-      .get('/hello')
-      .set('Authorization', `Bearer ${token}`)
-      .expect(400)
-      .then((res: any) => {
-        expect(res.text).toEqual('Token payload malformed, was {"iat":1,\"permission\":\"helloWorld\"}')
-      })
-  })
+    it('returns 400 and error message if not authenticated', async () => {
+      const token = JWT.sign({ iat: 1, permission: 'helloWorld' }, 'secret')
+      return server
+        .get(`/${apiType}/hello`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(400)
+        .then((res: any) => {
+          expect(res.text).toEqual('Token payload malformed, was {"iat":1,\"permission\":\"helloWorld\"}')
+        })
+    })
 
-  it('returns 401 and error message if token is malformed', async () =>
-    server
-      .get('/hello')
-      .set('Authorization', `Malformed token`)
-      .expect(401)
-      .then((res: any) => {
-        expect(res.text).toEqual('Format should be "Authorization: Bearer [token]", received "Authorization: Malformed token" instead')
-      })
-  )
+    it('returns 401 and error message if token is malformed', async () =>
+      server
+        .get(`/${apiType}/hello`)
+        .set('Authorization', `Malformed token`)
+        .expect(401)
+        .then((res: any) => {
+          expect(res.text).toEqual('Format should be "Authorization: Bearer [token]", received "Authorization: Malformed token" instead')
+        })
+    )
 
-  it('returns 401 and error message if payload is malformed', async () => {
-    return server
-      .get('/hello')
-      .set('Authorization', `Malformed token`)
-      .expect(401)
-      .then((res: any) => {
-        expect(res.text).toEqual('Format should be "Authorization: Bearer [token]", received "Authorization: Malformed token" instead')
-      })
-  })
+    it('returns 401 and error message if payload is malformed', async () => {
+      return server
+        .get(`/${apiType}/hello`)
+        .set('Authorization', `Malformed token`)
+        .expect(401)
+        .then((res: any) => {
+          expect(res.text).toEqual('Format should be "Authorization: Bearer [token]", received "Authorization: Malformed token" instead')
+        })
+    })
 
-  it('returns 401 and error message if token is missing', async () => {
-    return server
-      .get('/hello')
-      .expect(401)
-      .then((res: any) => {
-        expect(res.text).toEqual('No valid bearer token was set in the authorization header')
-      })
+    it('returns 401 and error message if token is missing', async () => {
+      return server
+        .get(`/${apiType}/hello`)
+        .expect(401)
+        .then((res: any) => {
+          expect(res.text).toEqual('No valid bearer token was set in the authorization header')
+        })
+    })
   })
 })

--- a/src/interfaces/IAuthorizedEvent.spec.ts
+++ b/src/interfaces/IAuthorizedEvent.spec.ts
@@ -12,6 +12,20 @@ describe('IAuthorizedEvent', () => {
       expect(event).not.toBeNull()
     })
 
+    it('accepts data that has a requestContext.http object and a string as an Authorization header', () => {
+      const event: IAuthorizedEvent = {
+        headers: {
+          Authorization: 'Bearer TOKEN'
+        },
+        requestContext: {
+          http: {
+            method: 'GET'
+          }
+        }
+      }
+      expect(event).not.toBeNull()
+    })
+
     it('accepts data that has an httpMethod and an Array as an Authorization header', () => {
       const event: IAuthorizedEvent = {
         headers: {
@@ -63,6 +77,21 @@ describe('IAuthorizedEvent', () => {
                 [authHeader]: 'Bearer TOKEN'
               },
               httpMethod: 'GET'
+            })
+          ).toBe(true)
+        })
+
+        it(`accepts data that has a requestContext.http object and a string as an ${authHeader} header`, () => {
+          expect(
+            isAuthorizedEvent({
+              headers: {
+                [authHeader]: 'Bearer TOKEN'
+              },
+              requestContext: {
+                http: {
+                  method: 'GET'
+                }
+              }
             })
           ).toBe(true)
         })
@@ -131,6 +160,63 @@ describe('IAuthorizedEvent', () => {
             isAuthorizedEvent({
               headers: {
                 [authHeader]: 'Bearer TOKEN'
+              }
+            })
+          ).toBe(false)
+        })
+
+        it('rejects data where httpMethod is an object', () => {
+          expect(
+            isAuthorizedEvent({
+              headers: {
+                [authHeader]: 'Bearer TOKEN'
+              },
+              httpMethod: { name: 'GET' }
+            })
+          ).toBe(false)
+        })
+
+        it('rejects data where httpMethod is a number', () => {
+          expect(
+            isAuthorizedEvent({
+              headers: {
+                [authHeader]: 'Bearer TOKEN'
+              },
+              httpMethod: 1
+            })
+          ).toBe(false)
+        })
+
+        it('rejects data where requestContext is a string', () => {
+          expect(
+            isAuthorizedEvent({
+              headers: {
+                [authHeader]: 'Bearer TOKEN'
+              },
+              requestContext: 'GET'
+            })
+          ).toBe(false)
+        })
+
+        it('rejects data where requestContext is null', () => {
+          expect(
+            isAuthorizedEvent({
+              headers: {
+                [authHeader]: 'Bearer TOKEN'
+              },
+              requestContext: null
+            })
+          ).toBe(false)
+        })
+
+        it('rejects data where requestContext.http is a string', () => {
+          expect(
+            isAuthorizedEvent({
+              headers: {
+                [authHeader]: 'Bearer TOKEN'
+              },
+              requestContext: {
+                http: 'GET'
               }
             })
           ).toBe(false)

--- a/src/interfaces/IAuthorizedEvent.ts
+++ b/src/interfaces/IAuthorizedEvent.ts
@@ -3,7 +3,7 @@ export type IAuthorizedEvent<TokenPayload = any> =
   | ILowerCaseAuthorizedEvent<TokenPayload>
   | IUpperCaseAuthorizedEvent<TokenPayload>
 
-export type IAuthorizedEventBase<TokenPayload = any> = {
+export interface IAuthorizedEventBase<TokenPayload = any> {
   /** Authorization information added by this middleware from a JWT. Has to be undefined before hitting the middleware. */
   auth?: {
     payload: TokenPayload
@@ -11,19 +11,28 @@ export type IAuthorizedEventBase<TokenPayload = any> = {
   }
   /** An object containing event headers */
   headers: any
-} & (
-  | {
-      /** The http request method of this event (for REST APIs) */
-      httpMethod: string
-    }
-  | {
-      /** The metadata about this event (for HTTP APIs) */
-      requestContext: {
-        /** The http request metadata about this event */
-        http: object
-      }
-    }
-)
+  /** The http request method of this event (for REST APIs) */
+  httpMethod?: any
+  /** The metadata about this event (for HTTP APIs) */
+  requestContext?: any
+}
+
+export interface IAuthorizedRestApiGatewayEvent<TokenPayload = any>
+  extends IAuthorizedEventBase<TokenPayload> {
+  httpMethod: string
+}
+
+export interface IAuthorizedHttpApiGatewayEvent<TokenPayload = any>
+  extends IAuthorizedEventBase<TokenPayload> {
+  requestContext: {
+    /** The http request metadata about this event */
+    http: object
+  }
+}
+
+export type IAuthorizedApiGatewayEvent<TokenPayload = any> =
+  | IAuthorizedRestApiGatewayEvent<TokenPayload>
+  | IAuthorizedHttpApiGatewayEvent<TokenPayload>
 
 /** An event with a lower case authorization header */
 export type ILowerCaseAuthorizedEvent<TokenPayload = any> = {
@@ -34,7 +43,7 @@ export type ILowerCaseAuthorizedEvent<TokenPayload = any> = {
      */
     authorization: string | string[]
   }
-} & IAuthorizedEventBase<TokenPayload>
+} & IAuthorizedApiGatewayEvent<TokenPayload>
 
 /** An event with an upper case authorization header */
 export type IUpperCaseAuthorizedEvent<TokenPayload = any> = {
@@ -45,7 +54,7 @@ export type IUpperCaseAuthorizedEvent<TokenPayload = any> = {
      */
     Authorization: string | string[]
   }
-} & IAuthorizedEventBase<TokenPayload>
+} & IAuthorizedApiGatewayEvent<TokenPayload>
 
 export function isAuthorizedEvent<P> (
   event: any,
@@ -63,11 +72,9 @@ export function isAuthorizedEventBase<P> (
 ): event is IAuthorizedEventBase {
   return (
     event != null &&
-    (typeof event.httpMethod === 'string' ||
-      (typeof event.requestContext === 'object' &&
-        event.requestContext !== null &&
-        typeof event.requestContext.http === 'object')) &&
     event.headers != null &&
+    event.httpMethod != null &&
+    event.requestContext != null &&
     (event.auth === undefined ||
       isTokenPayload == null ||
       (event.auth &&
@@ -76,12 +83,45 @@ export function isAuthorizedEventBase<P> (
   )
 }
 
+export function isAuthorizedRestApiGatewayEvent<P> (
+  event: any,
+  isTokenPayload?: (payload: any) => payload is P
+): event is IAuthorizedRestApiGatewayEvent<P> {
+  return (
+    isAuthorizedEventBase<P>(event, isTokenPayload) &&
+    typeof event.httpMethod === 'string'
+  )
+}
+
+export function isAuthorizedHttpApiGatewayEvent<P> (
+  event: any,
+  isTokenPayload?: (payload: any) => payload is P
+): event is IAuthorizedHttpApiGatewayEvent<P> {
+  return (
+    isAuthorizedEvent<P>(event, isTokenPayload) &&
+    typeof event.requestContext === 'object' &&
+    event.requestContext !== null &&
+    typeof event.requestContext.http === 'object'
+  )
+}
+
+export function isAuthorizedApiGatewayEvent<P> (
+  event: any,
+  isTokenPayload?: (payload: any) => payload is P
+): event is IAuthorizedApiGatewayEvent<P> {
+  return (
+    isAuthorizedEvent<P>(event, isTokenPayload) &&
+    (isAuthorizedRestApiGatewayEvent(event, isTokenPayload) ||
+      isAuthorizedHttpApiGatewayEvent(event, isTokenPayload))
+  )
+}
+
 export function isUpperCaseAuthorizedEvent<P> (
   event: any,
   isTokenPayload?: (payload: any) => payload is P
 ): event is IUpperCaseAuthorizedEvent<P> {
   return (
-    isAuthorizedEventBase<P>(event, isTokenPayload) &&
+    isAuthorizedApiGatewayEvent<P>(event, isTokenPayload) &&
     (typeof event.headers.Authorization === 'string' ||
       (Array.isArray(event.headers.Authorization) &&
         event.headers.Authorization.length === 1 &&
@@ -96,7 +136,7 @@ export function isLowerCaseAuthorizedEvent<P> (
   isTokenPayload?: (payload: any) => payload is P
 ): event is ILowerCaseAuthorizedEvent<P> {
   return (
-    isAuthorizedEventBase<P>(event, isTokenPayload) &&
+    isAuthorizedApiGatewayEvent<P>(event, isTokenPayload) &&
     (typeof event.headers.authorization === 'string' ||
       (Array.isArray(event.headers.authorization) &&
         event.headers.authorization.length === 1 &&

--- a/src/interfaces/IAuthorizedEvent.ts
+++ b/src/interfaces/IAuthorizedEvent.ts
@@ -98,7 +98,7 @@ export function isAuthorizedHttpApiGatewayEvent<P> (
   isTokenPayload?: (payload: any) => payload is P
 ): event is IAuthorizedHttpApiGatewayEvent<P> {
   return (
-    isAuthorizedEvent<P>(event, isTokenPayload) &&
+    isAuthorizedEventBase<P>(event, isTokenPayload) &&
     typeof event.requestContext === 'object' &&
     event.requestContext !== null &&
     typeof event.requestContext.http === 'object'
@@ -110,9 +110,8 @@ export function isAuthorizedApiGatewayEvent<P> (
   isTokenPayload?: (payload: any) => payload is P
 ): event is IAuthorizedApiGatewayEvent<P> {
   return (
-    isAuthorizedEvent<P>(event, isTokenPayload) &&
-    (isAuthorizedRestApiGatewayEvent(event, isTokenPayload) ||
-      isAuthorizedHttpApiGatewayEvent(event, isTokenPayload))
+    isAuthorizedRestApiGatewayEvent(event, isTokenPayload) ||
+      isAuthorizedHttpApiGatewayEvent(event, isTokenPayload)
   )
 }
 

--- a/src/interfaces/IAuthorizedEvent.ts
+++ b/src/interfaces/IAuthorizedEvent.ts
@@ -73,8 +73,7 @@ export function isAuthorizedEventBase<P> (
   return (
     event != null &&
     event.headers != null &&
-    event.httpMethod != null &&
-    event.requestContext != null &&
+    (event.httpMethod != null || event.requestContext != null) &&
     (event.auth === undefined ||
       isTokenPayload == null ||
       (event.auth &&
@@ -111,7 +110,7 @@ export function isAuthorizedApiGatewayEvent<P> (
 ): event is IAuthorizedApiGatewayEvent<P> {
   return (
     isAuthorizedRestApiGatewayEvent(event, isTokenPayload) ||
-      isAuthorizedHttpApiGatewayEvent(event, isTokenPayload)
+    isAuthorizedHttpApiGatewayEvent(event, isTokenPayload)
   )
 }
 

--- a/test/serverless.yml
+++ b/test/serverless.yml
@@ -8,6 +8,8 @@ plugins:
 provider:
   name: aws
   runtime: nodejs8.10
+  httpApi:
+    payload: '2.0'
 
 functions:
   hello:
@@ -15,11 +17,14 @@ functions:
     events:
       - http:
           method: get
-          path: hello
+          path: /rest/hello
+      - httpApi:
+          method: get
+          path: /http/hello
 
   status:
     handler: handler.status
     events:
       - http:
           method: get
-          path: status
+          path: /status


### PR DESCRIPTION
Thanks for the awesome library :raised_hands: 

V2 HTTP APIs on API Gateway expose a requestContext.http object, rather than a httpMethod property (as opposed to REST APIs). This PR adds support for this, allowing the library to be used for V2 HTTP APIs.

Related documentation:
- AWS on API Gateway / Lambda integrations for HTTP APIs: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
- Serverless framework on HTTP API: https://www.serverless.com/framework/docs/providers/aws/events/http-api